### PR TITLE
Feature/add quickedit support

### DIFF
--- a/admin/class-quick-edit-support.php
+++ b/admin/class-quick-edit-support.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Subtitles_Quick_Edit_Support enables quick editing of subtitles on
+ * the post edit screens. It uses the same 'save_post' hook as
+ * Subtitles_Admin.
+ *
+ * Quick edit support can be turned off by using the
+ * subtitles_quick_edit_support hook. Default is true (enabled);
+ */
+class Subtitles_Quick_Edit_Support {
+
+	/**
+	 * Subscribes to the quick edit custom box to render the markup.
+	 */
+	public function register() {
+		if ( apply_filters( 'subtitles_quick_edit_support', true ) ) {
+			add_action(
+				'quick_edit_custom_box', array( $this, 'render' ), 100
+			);
+		}
+	}
+
+	/** Helpers */
+
+	/**
+	 * Renders the subtitle form fields markup and nonce.
+	 *
+	 * NOTE: The value of the subtitle field is intentionally left at '-' instead of
+	 * populating it with the stored value post meta. The wp-admin/js/inline-edit-post.js in
+	 * Core hardcodes the list of fields used in the quick edit form.
+	 *
+	 * There is no easy way to override this without modifying Core.
+	 *
+	 * The special '-' value will be ignored by the save hook. All other
+	 * values are valid and are saved to post meta as earlier.
+	 */
+	function render() {
+		$subtitle_field = $this->get_field_name();
+
+		wp_nonce_field(
+			$this->get_nonce_action(),
+			$this->get_nonce_name(),
+			true,
+			true
+		);
+
+		?>
+		<fieldset class="inline-edit-col-right">
+			<div class="inline-edit-col">
+				<label>
+					<span class="title"><?php _e( 'Subtitle' ); ?></span>
+					<span class="input-text-wrap">
+					<input type="text" name="<?php _e( $subtitle_field ); ?>" class="ptitle"
+						value="-" />
+					</span>
+				</label>
+			</div>
+		</fieldset>
+		<?php
+	}
+
+	/**
+	 * The same nonce action from subtitles admin
+	 */
+	function get_nonce_action() {
+		return basename( __DIR__ . '/class-subtitles-admin.php' );
+	}
+
+	/**
+	 * The same nonce name from subtitles admin
+	 */
+	function get_nonce_name() {
+		return Subtitles_Admin::SUBTITLE_NONCE_NAME;
+	}
+
+	/**
+	 * The same field name from subtitles admin
+	 */
+	function get_field_name() {
+		return Subtitles_Admin::SUBTITLE_META_KEY;
+	}
+
+}

--- a/admin/class-subtitles-admin.php
+++ b/admin/class-subtitles-admin.php
@@ -37,10 +37,18 @@ if ( ! class_exists( 'Subtitles_Admin' ) ) {
 		 * @since 1.0.3
 		 */
 		private static $instance = null;
+		private static $quick_edit_support = null;
 
 		public static function getinstance() {
 			if ( ! self::$instance ) {
 				self::$instance = new Subtitles_Admin;
+			}
+
+			if ( ! self::$quick_edit_support ) {
+				require_once( __DIR__ . '/class-quick-edit-support.php' );
+
+				self::$quick_edit_support = new Subtitles_Quick_Edit_Support();
+				self::$quick_edit_support->register();
 			}
 
 			return self::$instance;
@@ -263,6 +271,18 @@ if ( ! class_exists( 'Subtitles_Admin' ) ) {
 			$new_subtitle = (string) isset( $_POST[ $subtitle_meta_key ] ) ? wp_kses( $_POST[ $subtitle_meta_key ], $subtitles_allowed_tags ) : null;
 			// Get the current subtitle assigned to the post
 			$current_subtitle = (string) wp_kses( get_post_meta( $post_id, $subtitle_meta_key, true ), $subtitles_allowed_tags );
+
+			/**
+			 * KLUDGE:
+			 *
+			 * Ignore the subtitle value of '-'. This hack is needed since we can't give
+			 * subtitle values to each quick edit subtitle. Otherwise
+			 * all quick edits subtitles will be rendered with the subtitle of the first
+			 * post in the list table.
+			 */
+			if ( $new_subtitle === '-' ) {
+				return;
+			}
 
 			/**
 			 * Add meta when key is new or empty for post

--- a/subtitles.php
+++ b/subtitles.php
@@ -178,7 +178,7 @@ require plugin_dir_path( __FILE__ ) . 'public/includes/template-tags.php';
  * @since 1.0.0
  */
 
-if ( is_admin() && ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) ) {
+if ( is_admin() ) {
 	require plugin_dir_path( __FILE__ ) . 'admin/class-subtitles-admin.php';
 
 	add_action(


### PR DESCRIPTION
I added support for subtitles in the Quick Edit view in this PR. I used the [quick_edit_custom](https://codex.wordpress.org/Plugin_API/Action_Reference/quick_edit_custom_box) hook to add the inline subtitle field. This works but is a little kludgy due to a couple of limitations in the Quick Edit View.

1. You can't add a custom field after the Title field. That would have been ideal. Instead, the subtitle field is in the right column.

2. The default value of the subtitle field is set to '-'. Core's quick edit JS resets the quick edit view using a hard coded list of fields. So there is no easy way to show the stored subtitle. I opted to use the '-' as a special value that is ignored by `save_post`.

Screencast: https://vid.me/75mk5